### PR TITLE
Add tests for Xai provider

### DIFF
--- a/crates/goose-server/src/routes/providers_and_keys.json
+++ b/crates/goose-server/src/routes/providers_and_keys.json
@@ -29,7 +29,7 @@
         "models": ["gemini-1.5-flash"],
         "required_keys": ["GOOGLE_API_KEY"]
     },
-    "grok": {
+    "groq": {
         "name": "Groq",
         "description": "Lorem ipsum",
         "models": ["llama-3.3-70b-versatile"],
@@ -58,5 +58,11 @@
         "description": "Connect to LLMs via AWS Bedrock",
         "models": ["us.anthropic.claude-3-7-sonnet-20250219-v1:0"],
         "required_keys": ["AWS_PROFILE"]
-    }
+    },
+    "xai": {
+        "name": "Xai",
+        "description": "Lorem ipsum",
+        "models": ["grok-3"],
+        "required_keys": ["XAI_API_KEY"]
+    },
 }

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -12,7 +12,7 @@ use goose::providers::{
     anthropic::AnthropicProvider, azure::AzureProvider, bedrock::BedrockProvider,
     databricks::DatabricksProvider, gcpvertexai::GcpVertexAIProvider, google::GoogleProvider,
     groq::GroqProvider, ollama::OllamaProvider, openai::OpenAiProvider,
-    openrouter::OpenRouterProvider,
+    openrouter::OpenRouterProvider, xai::XaiProvider,
 };
 
 #[derive(Debug, PartialEq)]
@@ -27,6 +27,7 @@ enum ProviderType {
     Groq,
     Ollama,
     OpenRouter,
+    Xai,
 }
 
 impl ProviderType {
@@ -46,6 +47,7 @@ impl ProviderType {
             ProviderType::Ollama => &[],
             ProviderType::OpenRouter => &["OPENROUTER_API_KEY"],
             ProviderType::GcpVertexAI => &["GCP_PROJECT_ID", "GCP_LOCATION"],
+            ProviderType::Xai => &["XAI_API_KEY"],
         }
     }
 
@@ -79,6 +81,7 @@ impl ProviderType {
             ProviderType::Groq => Arc::new(GroqProvider::from_env(model_config)?),
             ProviderType::Ollama => Arc::new(OllamaProvider::from_env(model_config)?),
             ProviderType::OpenRouter => Arc::new(OpenRouterProvider::from_env(model_config)?),
+            ProviderType::Xai => Arc::new(XaiProvider::from_env(model_config)?),
         })
     }
 }
@@ -323,6 +326,16 @@ mod tests {
             provider_type: ProviderType::GcpVertexAI,
             model: "claude-3-5-sonnet-v2@20241022",
             context_window: 200_000,
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_agent_with_xai() -> Result<()> {
+        run_test_with_config(TestConfig {
+            provider_type: ProviderType::Xai,
+            model: "grok-3",
+            context_window: 9_000,
         })
         .await
     }

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -4,7 +4,7 @@ use goose::message::{Message, MessageContent};
 use goose::providers::base::Provider;
 use goose::providers::errors::ProviderError;
 use goose::providers::{
-    anthropic, azure, bedrock, databricks, google, groq, ollama, openai, openrouter, snowflake,
+    anthropic, azure, bedrock, databricks, google, groq, ollama, openai, openrouter, snowflake, xai,
 };
 use mcp_core::content::Content;
 use mcp_core::tool::Tool;
@@ -497,6 +497,17 @@ async fn test_sagemaker_tgi_provider() -> Result<()> {
         &["SAGEMAKER_ENDPOINT_NAME"],
         None,
         goose::providers::sagemaker_tgi::SageMakerTgiProvider::default,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_xai_provider() -> Result<()> {
+    test_provider(
+        "Xai",
+        &["XAI_API_KEY"],
+        None,
+        xai::XaiProvider::default,
     )
     .await
 }


### PR DESCRIPTION
Adds some tests requested by @salman1993 here: https://github.com/block/goose/pull/2976#issuecomment-2982424895

```
 ~/Documents/code/goose/ [add-xai-tests] cargo test test_xai_provider --test providers
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running tests/providers.rs (target/debug/deps/providers-a220957366eecf4c)

running 1 test
test test_xai_provider ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s


============== Providers ==============
⏭️ Xai
=======================================

 ~/Documents/code/goose/ [add-xai-tests] cargo test test_agent_with_xai --test agent  
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.24s
     Running tests/agent.rs (target/debug/deps/agent-da2b34cd632a2304)

running 1 test
test tests::test_agent_with_xai ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s
```
